### PR TITLE
doxygen new

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,25 @@
+name: Doxygen
+
+on:
+   pull_request:
+
+jobs:
+
+  Doxygen:
+    name: Run doxygen
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2.3.4
+      with:
+        fetch-depth: 100
+    - name: Install software
+      run: sudo apt-get install doxygen
+    - name: Check files
+      run: ./ci/copy_doxygen_files.sh
+    - name: Add problem matcher
+      run: echo ::add-matcher::ci/daos-doxygen-matcher.json
+    - name: Run
+      run: doxygen Doxyfile
+    - name: Remove matcher
+      run: echo "::remove-matcher owner=daos-doxygen::"

--- a/Doxyfile
+++ b/Doxyfile
@@ -905,7 +905,7 @@ FILE_PATTERNS          = *.c \
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = YES
+RECURSIVE              = NO
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -914,15 +914,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = src/include/cart \
-                         src/include/daos \
-                         src/include/daos_srv \
-                         src/include/gurt \
-                         src/include/daos.h \
-                         src/include/daos_mgmt.h \
-                         src/include/daos_pool.h \
-                         src/include/daos_prop.h \
-                         src/include/dfuse_ioctl.h
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/ci/copy_doxygen_files.sh
+++ b/ci/copy_doxygen_files.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Prepare the source tree for Doxygen, see .github/workflows/doxygen.yml
+
+set -ex
+
+# Load the list of modified files.
+git fetch
+git branch -lr
+FILES=$(git diff --name-only origin/master... src/include)
+
+# Create a new temp directory.
+mkdir src/include2
+
+# Copy modified files into it.
+for FILE in $FILES
+do
+    cp "$FILE" ./src/include2
+done
+
+# Move real path aside.
+mv src/include src/include.old
+
+# And place the modified ones back in place.
+mv src/include2 src/include
+
+# Ensure there is at least one file present.
+if [ -f src/include.old/daos.h ]
+then
+    mv src/include.old/daos.h src/include
+fi

--- a/ci/daos-doxygen-matcher.json
+++ b/ci/daos-doxygen-matcher.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "daos-doxygen",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):\\s(warning|error):\\s(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "severity": 3,
+                    "message": 4,
+                }
+            ]
+        }
+    ]
+}

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -36,8 +36,8 @@ typedef struct {
 /**
  * Stop the current pool service leader.
  *
- * \param poh	[IN]	Pool connection handle
- * \param ev	[IN]	Completion event, it is optional and can be NULL.
+ * \param[in] poh	Pool connection handle
+ * \param[in] ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
  * \return		These values will be returned by \a ev::ev_error in
@@ -66,15 +66,15 @@ enum {
 /**
  * Set parameter on servers.
  *
- * \param grp	[IN]	Process set name of the DAOS servers managing the pool
- * \param rank	[IN]	Ranks to set parameter. -1 means setting on all servers.
- * \param key_id [IN]	key ID of the parameter.
- * \param value [IN]	value of the parameter.
- * \param value_extra [IN]
+ * \param[in] grp	Process set name of the DAOS servers managing the pool
+ * \param[in] rank	Ranks to set parameter. -1 means setting on all servers.
+ * \param[in] key_id	key ID of the parameter.
+ * \param[in] value	value of the parameter.
+ * \param[in] value_extra
  *			optional extra value to set the fail value when
  *			\a key_id is DMG_CMD_FAIL_LOC and \a value is in
  *			DAOS_FAIL_VALUE mode.
- * \param ev	[IN]	Completion event, it is optional and can be NULL.
+ * \param[in] ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
 int
@@ -84,7 +84,7 @@ daos_debug_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
 /**
  * Add mark to servers.
  *
- * \param mark	[IN]	mark to add to the debug log.
+ * \param[in] mark	mark to add to the debug log.
  */
 int
 daos_debug_add_mark(const char *mark);
@@ -93,12 +93,12 @@ daos_debug_add_mark(const char *mark);
  * Query internal blobstore state for given blobstore uuid in the specified
  * DAOS system.
  *
- * \param group		  [IN]	Name of DAOS system managing the service.
- * \param blobstore_uuid  [IN]	UUID of the blobstore to query.
- * \param blobstore_state [OUT] Will return an enum integer that will
+ * \param[in] group		Name of DAOS system managing the service.
+ * \param[in] blobstore_uuid	UUID of the blobstore to query.
+ * \param[out] blobstore_state	Will return an enum integer that will
  *				later be converted to a blobstore state:
  *				SETUP, NORMAL, FAULTY, TEARDOWN, or OUT
- * \param ev		  [IN]  Completion event. Optional and can be NULL.
+ * \param[in] ev		Completion event. Optional and can be NULL.
  *				The function will run in blocking mode
  *				if \a ev is NULL.
  *
@@ -108,7 +108,6 @@ daos_debug_add_mark(const char *mark);
 int
 daos_mgmt_get_bs_state(const char *group, uuid_t blobstore_uuid,
 		       int *blobstore_state, daos_event_t *ev);
-
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -198,7 +198,7 @@ enum daos_cont_props {
 	DAOS_PROP_CO_MAX,
 };
 
-/* first citizen objects of a container, stored as container property */
+/** first citizen objects of a container, stored as container property */
 struct daos_prop_co_roots {
 	daos_obj_id_t	cr_oids[4];
 };
@@ -299,11 +299,11 @@ enum {
 /** clear the UNCLEAN status */
 #define DAOS_PROP_CO_CLEAR	(0x1)
 struct daos_co_status {
-	/* DAOS_PROP_CO_HEALTHY/DAOS_PROP_CO_UNCLEAN */
+	/** DAOS_PROP_CO_HEALTHY/DAOS_PROP_CO_UNCLEAN */
 	uint16_t	dcs_status;
-	/* flags for DAOS internal usage, DAOS_PROP_CO_CLEAR */
+	/** flags for DAOS internal usage, DAOS_PROP_CO_CLEAR */
 	uint16_t	dcs_flags;
-	/* pool map version when setting the dcs_status */
+	/** pool map version when setting the dcs_status */
 	uint32_t	dcs_pm_ver;
 };
 
@@ -377,7 +377,6 @@ daos_prop_alloc(uint32_t entries_nr);
 void
 daos_prop_fini(daos_prop_t *prop);
 
-
 /**
  * Free the DAOS properties and the \a prop.
  *
@@ -401,7 +400,7 @@ daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop);
  * Duplicate a generic pointer value from one DAOS prop entry to another.
  * Convenience function.
  *
- * \param[in][out]	entry_dst	Destination entry
+ * \param[in,out]	entry_dst	Destination entry
  * \param[in]		entry_src	Entry to be copied
  * \param[in]		len		Length of the memory to be copied
  *
@@ -429,7 +428,7 @@ daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
  * Duplicate container roots from one DAOS prop entry to another.
  * Convenience function.
  *
- * \param[in][out]	dst		Destination entry
+ * \param[in,out]	dst		Destination entry
  * \param[in]		src		Entry to be copied
  *
  * \return		0		Success


### PR DESCRIPTION
- DAOS-6710 rsvc: get_attr to continue upon non-existent attr (#5859)
- DAOS-7910 tools: Handle empty ACL in daos cont get-acl (#6011)
- DAOS-7895 test: Check the out_queue for None. (#5991)
- DOAS-7484 build: Use pkgconfig even for built dependencies (#5996)
- DAOS-7875 control: Set nr_hugepages for auto generate config file (#5977)
- DAOS-7813 build: Local repos for RPM builds (#5990)
- DAOS-7521 doc: update posix.md (#6023)
- DAOS-7505 doc: Remove SUSE 15.2 from 1.2 support (#5939)
- DAOS-7869 dfuse: Add a --path option to dfuse and clean up arg parsing. (#5952)
- DAOS-5692 tools: Automatically generate man pages (#5989)
- Revert "DAOS-623 build: Use shallow clone when building deps." (#6022)
- DAOS-7844 csum: Improve IOD Is Valid Check (#5979)
- DAOS-7813 build: Fix el8 appstream mirror use (#6031)
- DAOS-7295 bio: Fixing uninitialized variable in bio_write_blob_hdr() (#5541)
- DAOS-7821 ga: Add Github build for Doxygen
